### PR TITLE
Update package.json with repo-url so .install.sh works

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
 	"engines": {
 		"vscode": "^1.63.0"
 	},
+  	"repository": {
+	    "type": "git",
+	    "url": "https://github.com/tomimick/tomitool-vsext"
+	  },
 	"categories": [
 		"Other"
 	],


### PR DESCRIPTION
`package.json` was missing the repo url so the `./install.sh` command kept failing. 

This fixes that so the extension installs correctly.